### PR TITLE
Adds single role field to user

### DIFF
--- a/db/migrate/20140804111244_add_role_to_users.rb
+++ b/db/migrate/20140804111244_add_role_to_users.rb
@@ -1,0 +1,5 @@
+class AddRoleToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :role, :string, default: 'applicant', after: :email
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20140722085450) do
+ActiveRecord::Schema.define(:version => 20140804111244) do
 
   create_table "answers", :force => true do |t|
     t.datetime "created_at",  :null => false
@@ -173,8 +173,9 @@ ActiveRecord::Schema.define(:version => 20140722085450) do
   end
 
   create_table "users", :force => true do |t|
-    t.string   "email",                  :default => "",   :null => false
-    t.string   "encrypted_password",     :default => "",   :null => false
+    t.string   "email",                  :default => "",          :null => false
+    t.string   "role",                   :default => "applicant"
+    t.string   "encrypted_password",     :default => "",          :null => false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
@@ -183,8 +184,8 @@ ActiveRecord::Schema.define(:version => 20140722085450) do
     t.datetime "last_sign_in_at"
     t.string   "current_sign_in_ip"
     t.string   "last_sign_in_ip"
-    t.datetime "created_at",                               :null => false
-    t.datetime "updated_at",                               :null => false
+    t.datetime "created_at",                                      :null => false
+    t.datetime "updated_at",                                      :null => false
     t.string   "avatar_file_name"
     t.string   "avatar_content_type"
     t.integer  "avatar_file_size"


### PR DESCRIPTION
First iteration of rewirite of role system, adds field that satisfies requirement one user, one role. Default role in migration is applicant, due to few admins in production, every admin will get the admin role manually after migration is done.
