### PR TITLE
Grammatical Mistake

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -104,7 +104,7 @@
     <div class="row">
       <footer class="main-footer col-md-12 text-center">
       <%= link_to image_tag("logo2013.png", :class => "footer-logo"), "http://www.isfit.org/" %>
-      <p>All written material and the ISFiT logo is copyrighted the ISFiT Foundation &copy;  2014.</p>
+      <p>All written material and the ISFiT logo is copyrighted to the ISFiT Foundation &copy;  <%= Time.now.year %>.</p>
       </footer>
     </div>
   </div>


### PR DESCRIPTION
Changed [copyrighted the ISFiT Foundation] to [copyrighted to the ISFiT Foundation]
And changed the year 2014 to [Time.now.year] as no one need to keep changing it every year.
